### PR TITLE
Fix error on empty list destroy

### DIFF
--- a/list_array/src/linkedlist.c
+++ b/list_array/src/linkedlist.c
@@ -37,17 +37,12 @@ void list_destroy(LinkedList *list)
 {
     list_alloc_test(list);
 
-    Element *elementCurrent, *elementNext;
-
-    elementCurrent = list->first;
-    while (elementCurrent != NULL)
-    {
-        elementNext = elementCurrent->next;
-        free(elementCurrent);
-        elementCurrent = elementNext;
+    Element *element = list->first;
+    while (element) {
+            Element *next = element->next;
+            free(element);
+            element = next;
     }
-    free(elementCurrent);
-    free(elementNext);
     free(list);
 }
 

--- a/list_array/src/linkedlist.c
+++ b/list_array/src/linkedlist.c
@@ -25,7 +25,7 @@ LinkedList *list_init()
     element->value = 0;
     element->next = NULL;
     element->previous = NULL;
-    
+
     list->first = element;
     list->last = element;
     list->size = 0;
@@ -73,7 +73,7 @@ void list_add(LinkedList *list, int iValueToAdd)
     // If the list was empty
     if (list->size == 0)
     {
-        // Be careful we need to free the first element because it was 
+        // Be careful we need to free the first element because it was
         // initiated.
         free(list->first);
         element->previous = NULL;
@@ -86,7 +86,7 @@ void list_add(LinkedList *list, int iValueToAdd)
         element->previous = list->last;
         list->last->next = element;
     }
-    
+
     list->last = element;
     list->size += 1;
 }
@@ -96,7 +96,7 @@ void list_del(LinkedList *list, int iValueToDel)
     list_alloc_test(list);
 
     Element *elementCurrent, *elementPrevious;
-    
+
     // List empty
     if (list->size == 0)
     {
@@ -175,7 +175,7 @@ int list_get(LinkedList *list, int iPosition)
     list_alloc_test(list);
 
     Element *elementCurrent;
-   
+
     // Check if position asked is present in the list.
     if (iPosition > list->size - 1)
     {

--- a/list_array/src/main.c
+++ b/list_array/src/main.c
@@ -74,5 +74,9 @@ int main( int argc, char *argv[] )
 
     list_destroy(list);
 
+    LinkedList *empty;
+    empty = list_init();
+    list_destroy(empty);
+
     return 0;
 }

--- a/list_array/src/main.c
+++ b/list_array/src/main.c
@@ -72,11 +72,11 @@ int main( int argc, char *argv[] )
     el = list_get(list, 2);
     printf("%d\n", el);
 
-    list_destroy(list);
+    printf("Removing all items of list");
+    list_del(list, 1);
+    list_del(list, 2);
 
-    LinkedList *empty;
-    empty = list_init();
-    list_destroy(empty);
+    list_destroy(list);
 
     return 0;
 }

--- a/list_array/src/main.c
+++ b/list_array/src/main.c
@@ -5,7 +5,7 @@
 |   Comments:   IIC2133 - estructuras de datos - tarea1
 \******************************************************************************/
 
-#include <stdio.h> 
+#include <stdio.h>
 #include <stdlib.h>
 
 #include "array.h"
@@ -22,25 +22,25 @@ int main( int argc, char *argv[] )
 
     printf("Empty array\n");
     array_print(array);
-    
+
     printf("Array with 1, 2 and 3 added.\n");
     array_add(array, 1);
     array_add(array, 2);
     array_add(array, 3);
     array_print(array);
-    
+
     printf("Array delete the 3.\n");
     array_del(array, 3);
     array_print(array);
-   
- 
+
+
     printf("Looking for element at position number 1.\n");
     el = array_get(array, 1);
     printf("%d\n", el);
 
     printf("Looking for element at position number 2.\n");
     el = array_get(array, 2);
-    printf("%d\n", el); 
+    printf("%d\n", el);
 
     array_destroy(array);
 
@@ -53,26 +53,26 @@ int main( int argc, char *argv[] )
 
     printf("Empty list\n");
     list_print(list);
-    
+
     printf("LinkedList with 1, 2 and 3 added.\n");
     list_add(list, 1);
     list_add(list, 2);
     list_add(list, 3);
     list_print(list);
-    
+
     printf("LinkedList with 3 deleted.\n");
     list_del(list, 3);
     list_print(list);
- 
+
     printf("Looking for element at position number 1.\n");
     el = list_get(list, 1);
     printf("%d\n", el);
 
     printf("Looking for element at position number 2.\n");
     el = list_get(list, 2);
-    printf("%d\n", el); 
+    printf("%d\n", el);
 
     list_destroy(list);
- 
+
     return 0;
 }


### PR DESCRIPTION
There was a problem when destroying a empty list. One of the pointers being freed was not allocated.

Changed:

``` c
void list_destroy(LinkedList *list)
{
    list_alloc_test(list);

    Element *elementCurrent, *elementNext;

    elementCurrent = list->first;
    while (elementCurrent != NULL)
    {
        elementNext = elementCurrent->next;
        free(elementCurrent);
        elementCurrent = elementNext;
    }
    free(elementCurrent);
    free(elementNext);
    free(list);
}
```

And simplified to:

``` c
void list_destroy(LinkedList *list)
{
    list_alloc_test(list);

    Element *element = list->first;
    while (element) {
            Element *next = element->next;
            free(element);
            element = next;
    }
    free(list);
}
```

You can check the error adding 

``` c
    // ...
    printf("Removing all items of list");
    list_del(list, 1);
    list_del(list, 2);

    list_destroy(list);
```

To the end of the `main.c`.

---

Tested memory leaks with valgrind:

```
==34128== HEAP SUMMARY:
==34128==     in use at exit: 26,428 bytes in 187 blocks
==34128==   total heap usage: 270 allocs, 84 frees, 32,716 bytes allocated
==34128==
==34128== LEAK SUMMARY:
==34128==    definitely lost: 0 bytes in 0 blocks
==34128==    indirectly lost: 0 bytes in 0 blocks
==34128==      possibly lost: 0 bytes in 0 blocks
==34128==    still reachable: 0 bytes in 0 blocks
==34128==         suppressed: 26,428 bytes in 187 blocks
```
